### PR TITLE
Fix heartbeat-boot.patch for v4.6.1

### DIFF
--- a/patches/heartbeat-boot.patch
+++ b/patches/heartbeat-boot.patch
@@ -2,11 +2,13 @@ diff --git a/node/router/src/heartbeat.rs b/node/router/src/heartbeat.rs
 --- a/node/router/src/heartbeat.rs
 +++ b/node/router/src/heartbeat.rs
 @@ -39,13 +39,13 @@ pub trait Heartbeat<N: Network>: Outbound<N> {
-     /// The duration in seconds to sleep in between heartbeat executions.
-     const HEARTBEAT_IN_SECS: u64 = 25; // 25 seconds
      /// The minimum number of peers required to maintain connections with.
 -    const MINIMUM_NUMBER_OF_PEERS: usize = 3;
 +    const MINIMUM_NUMBER_OF_PEERS: usize = 4;
+     /// The minimum time between connection attempts to a peer.
+     const MINIMUM_TIME_BETWEEN_CONNECTION_ATTEMPTS: Duration = Duration::from_secs(10);
+     /// The time we consider the node to be starting up and avoid certain warnings such as "No connected peers".
+     const STARTUP_GRACE_PERIOD: Duration = Duration::from_secs(60);
      /// The median number of peers to maintain connections with.
      const MEDIAN_NUMBER_OF_PEERS: usize = max(Self::MAXIMUM_NUMBER_OF_PEERS / 2, Self::MINIMUM_NUMBER_OF_PEERS);
      /// The maximum number of peers permitted to maintain connections with.
@@ -18,4 +20,3 @@ diff --git a/node/router/src/heartbeat.rs b/node/router/src/heartbeat.rs
      /// The amount of time an IP address is prohibited from connecting.
 -    const IP_BAN_TIME_IN_SECS: u64 = 300;
 +    const IP_BAN_TIME_IN_SECS: u64 = 600;
-


### PR DESCRIPTION
## Summary
- Upstream `heartbeat.rs` renamed `HEARTBEAT_IN_SECS` → `HEARTBEAT_INTERVAL` and added new constants (`MINIMUM_TIME_BETWEEN_CONNECTION_ATTEMPTS`, `STARTUP_GRACE_PERIOD`), shifting context lines
- `git apply heartbeat-boot.patch` fails during boot-patch image build
- Updated patch context to match current upstream; same 4 value changes preserved