### PR TITLE
Fix builder: install llvm-dev and libclang-dev for clang-sys/bindgen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt update && \
     apt install -y --no-install-recommends \
       curl git build-essential wget \
-      clang lld binutils \
+      clang lld binutils llvm-dev libclang-dev \
       gcc libssl-dev make pkg-config xz-utils ca-certificates && \
     apt clean && rm -rf /var/lib/apt/lists/*
 

--- a/service/snarkos-history-telemetry/Dockerfile
+++ b/service/snarkos-history-telemetry/Dockerfile
@@ -18,7 +18,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt update && \
     apt install -y --no-install-recommends \
       curl git build-essential wget \
-      clang lld binutils \
+      clang lld binutils llvm-dev libclang-dev \
       gcc libssl-dev make pkg-config xz-utils ca-certificates && \
     apt clean && rm -rf /var/lib/apt/lists/*
 

--- a/service/snarkos-no-features/Dockerfile
+++ b/service/snarkos-no-features/Dockerfile
@@ -18,7 +18,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt update && \
     apt install -y --no-install-recommends \
       curl git build-essential wget \
-      clang lld binutils \
+      clang lld binutils llvm-dev libclang-dev \
       gcc libssl-dev make pkg-config xz-utils ca-certificates && \
     apt clean && rm -rf /var/lib/apt/lists/*
 

--- a/service/snarkos-telemetry/Dockerfile
+++ b/service/snarkos-telemetry/Dockerfile
@@ -18,7 +18,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN apt update && \
     apt install -y --no-install-recommends \
       curl git build-essential wget \
-      clang lld binutils \
+      clang lld binutils llvm-dev libclang-dev \
       gcc libssl-dev make pkg-config xz-utils ca-certificates && \
     apt clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Problem

The **Build and Push SnarkOS** workflow fails during the Docker build step (telemetry / history-telemetry feature sets) with:

```
error: failed to run custom build command for `clang-sys v1.8.1`
cargo:warning=could not execute `llvm-config` ... "couldn't execute `llvm-config --prefix`
  (path=llvm-config) (error: No such file or directory (os error 2))"
thread 'main' panicked at clang-sys-1.8.1/build/dynamic.rs:225:45
ERROR: process "/bin/sh -c git checkout ... && cargo build --release --features history,telemetry"
  did not complete successfully: exit code: 101
```

## Root cause

The `telemetry` and `history` feature sets pull in `clang-sys` (via `bindgen`), which needs **`libclang`** and **`llvm-config`** at build time. The builder stage installed `clang lld binutils` but not the LLVM dev packages that provide `libclang.so` and `llvm-config`, so `clang-sys`'s build script panicked.

## Fix

Add `llvm-dev` (provides `llvm-config`) and `libclang-dev` (provides `libclang.so`) to the builder-stage `apt install` in all Dockerfiles for consistency:

- `Dockerfile`
- `service/snarkos-telemetry/Dockerfile`
- `service/snarkos-history-telemetry/Dockerfile`
- `service/snarkos-no-features/Dockerfile`

These packages are only installed in the discarded builder stage, so the runtime image is unaffected.

https://claude.ai/code/session_011UyaFFB58ZnFBdhVNWf23Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011UyaFFB58ZnFBdhVNWf23Z)_